### PR TITLE
Support for SwiftUI

### DIFF
--- a/BGSwift/Classes/BGExtent.swift
+++ b/BGSwift/Classes/BGExtent.swift
@@ -164,6 +164,15 @@ public class BGExtentBuilderGeneric {
             lhs.bg_unwrapped === rhs.bg_unwrapped
         }
     }
+    
+    public func bindingState<T>(_ value: T, comparison: @escaping (T, T) -> Bool) -> BGBindingState<T> {
+        let state = BGBindingState(value, comparison: comparison)
+        let inputState = BGState(value, comparison: comparison)
+        state.inputState = inputState
+        resources.append(state)
+        resources.append(inputState)
+        return state
+    }
 }
 
 public class BGExtentBuilder<Extent: BGExtent>: BGExtentBuilderGeneric {

--- a/BGSwift/Classes/BGResource.swift
+++ b/BGSwift/Classes/BGResource.swift
@@ -164,7 +164,7 @@ extension BGResourceInternal {
     }
 }
 
-public class BGMoment: BGResource, BGResourceInternal {
+public class BGMoment: BGResource, BGResourceInternal, ObservableObject {
     var subsequents = Set<BGSubsequentLink>()
     weak var supplier: BGBehavior?
     weak var owner: BGExtent?
@@ -176,6 +176,8 @@ public class BGMoment: BGResource, BGResourceInternal {
         guard case .updateable(let graph, let currentEvent) = updateable else {
             return
         }
+        
+        objectWillChange.send()
         
         _prevEvent = _event;
         _event = currentEvent
@@ -197,7 +199,7 @@ public class BGMoment: BGResource, BGResourceInternal {
 
 }
 
-public class BGTypedMoment<Type>: BGResource, BGResourceInternal, TransientResource {
+public class BGTypedMoment<Type>: BGResource, BGResourceInternal, TransientResource, ObservableObject {
     var subsequents = Set<BGSubsequentLink>()
     weak var supplier: BGBehavior?
     weak var owner: BGExtent?
@@ -217,6 +219,8 @@ public class BGTypedMoment<Type>: BGResource, BGResourceInternal, TransientResou
             return
         }
 
+        objectWillChange.send()
+        
         _prevEvent = _event;
 
         _value = newValue
@@ -249,7 +253,7 @@ public enum BGStateComparison {
     public enum Identical { case identical }
 }
 
-public class BGState<Type>: BGResource, BGResourceInternal, TransientResource {
+public class BGState<Type>: BGResource, BGResourceInternal, TransientResource, ObservableObject {
     var subsequents = Set<BGSubsequentLink>()
     weak var supplier: BGBehavior?
     weak var owner: BGExtent?
@@ -294,6 +298,7 @@ public class BGState<Type>: BGResource, BGResourceInternal, TransientResource {
         }
         
         if !valueEquals(newValue) {
+            objectWillChange.send()
             _prevValue = _value;
             _prevEvent = _event;
             
@@ -353,6 +358,19 @@ extension BGDemandable {
             return BGDemandLink(resource: resource, type: .reactive)
         default:
             preconditionFailure("Unknown `BGDemandable` type.")
+        }
+    }
+}
+
+public class BGBindingState<Type>: BGState<Type> {
+    public var inputState: BGState<Type>!
+    
+    public var bindingValue: Type {
+        get {
+            return value
+        }
+        set {
+            inputState.updateWithAction(newValue)
         }
     }
 }


### PR DESCRIPTION
These changes let us use BGSwift with SwiftUI.

Implementing ObservableObject in the various resources lets SwiftUI observe resource updates and update its views. I've not considered what this means for multi threading.

The BGBindingState is a way to support SwiftUI's two way bindings. 
* For things like TextField and Toggles, SwiftUI will both read and write to the same property to match its state. BG needs the writing to work as an updateWithAction. 
* Also reading and writing to the same resource means we cannot separately update the resource from some other behavior. So I create two resources which gives us full flexibility.

TODO
* [ ] investigate multithreaded updates
* [ ] more factory methods for BGBindingState
* [ ] Tests
* [ ] Example in the demo app?


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
