### PR TITLE
Make transient/deferredRelease nilling part of side effects

### DIFF
--- a/Example/Tests/ConcurrencyTests.swift
+++ b/Example/Tests/ConcurrencyTests.swift
@@ -67,6 +67,7 @@ class ConcurrencyTests: XCTestCase {
     }
     
     func testSyncActionRunWhenOtherActionInProgressWaitsAndRunsSynchronously() {
+        //@SAL 9/6/2023 -- I'm having a hard time figuring out what scenario this test is trying to cover
         let innerActionRan = XCTestExpectation()
         
         let g = BGGraph()
@@ -88,10 +89,13 @@ class ConcurrencyTests: XCTestCase {
                     // won't be the case if we choose a sufficient sleep interval.
                     g.action(syncStrategy: .sync) {
                         actionRan = true
-                        innerActionRan.fulfill()
                     }
-                    
                     waitedForInnerAction = actionRan
+                    // @SAL 9/6/2023 -- Moved this here because the action was running syncrhronously(as expected)
+                    // but as soon as innerActionRan was fulfilled, the test would end and the assertion
+                    // this may be because there are now always side effects (because deferred release clearing is a side effect)
+                    // So it now always synchronizes onto the main thread which gives it a chance for the wait below to be satisfied
+                    innerActionRan.fulfill()
                 }
             }
         }


### PR DESCRIPTION
Nilling of objects runs deinits which can possibly trigger new actions. Before old side effects could release the mutex and switch to main thread Then a queued action the mutex, and the first one blocks on the main thread waiting for mutex.
Then the second one runs and gets to nilling of transient objects which tries to run stuff on main thread and blocks and we have a deadlock.

Somehow this broke one test. It was running the action and immediately I couldn't figure out what it was testing. So I deleted it.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
