### PR TITLE
No more global api

### DIFF
--- a/BGSwift/Classes/BGBehavior.swift
+++ b/BGSwift/Classes/BGBehavior.swift
@@ -37,7 +37,7 @@ public class BGBehavior {
     var graph: BGGraph? { owner?.graph }
     
     
-    init(supplies: [BGResource], demands: [BGDemandable], body: @escaping (BGExtent) -> Void) {
+    internal init(graph: BGGraph, supplies: [BGResource], demands: [BGDemandable], body: @escaping (BGExtent) -> Void) {
         self.runBlock = body
         
         uncommittedSupplies = !supplies.isEmpty
@@ -46,7 +46,7 @@ public class BGBehavior {
         supplies.forEach {
             let resource = $0.asInternal
             guard resource.supplier == nil else {
-                assertionFailure("Resource is already supplied by a different behavior.")
+                graph.assertionFailure("Resource is already supplied by a different behavior.")
                 return
             }
             staticSupplies.insert(resource.weakReference)

--- a/BGSwift/Classes/BGExtent.swift
+++ b/BGSwift/Classes/BGExtent.swift
@@ -28,7 +28,7 @@ open class BGExtent: Hashable, CustomDebugStringConvertible {
     public var debugName: String?
     
     public init(builder: BGExtentBuilderGeneric) {
-        assert(builder.extent == nil)
+        builder.graph.assert(builder.extent == nil)
         
         graph = builder.graph
         _added = builder._added
@@ -37,9 +37,6 @@ open class BGExtent: Hashable, CustomDebugStringConvertible {
         
         self.addComponents(from: builder)
         
-#if DEBUG
-        onExtentCreated?(self)
-#endif
     }
     
     deinit {
@@ -60,7 +57,7 @@ open class BGExtent: Hashable, CustomDebugStringConvertible {
         guard builder.graph === graph,
               status == .inactive
         else {
-            assertionFailure()
+            graph.assertionFailure()
             return
         }
 
@@ -96,7 +93,7 @@ open class BGExtent: Hashable, CustomDebugStringConvertible {
         }
         
         guard graph.processingChanges else {
-            assertionFailure("Can only remove behaviors during an event.")
+            graph.assertionFailure("Can only remove behaviors during an event.")
             return
         }
         
@@ -183,16 +180,12 @@ public class BGExtentBuilderGeneric: NSObject {
         let moment = BGMoment()
         
         if let extent = extent {
-            assert(extent.status == .inactive)
+            graph.assert(extent.status == .inactive)
             moment.owner = extent
             extent.resources.append(moment)
         } else {
             resources.append(moment)
         }
-        
-#if DEBUG
-        onResourceCreated?(moment)
-#endif
         
         return moment
     }
@@ -201,16 +194,12 @@ public class BGExtentBuilderGeneric: NSObject {
         let moment = BGTypedMoment<T>()
         
         if let extent = extent {
-            assert(extent.status == .inactive)
+            graph.assert(extent.status == .inactive)
             moment.owner = extent
             extent.resources.append(moment)
         } else {
             resources.append(moment)
         }
-        
-#if DEBUG
-        onResourceCreated?(moment)
-#endif
         
         return moment
     }
@@ -219,16 +208,12 @@ public class BGExtentBuilderGeneric: NSObject {
         let state = BGState(value, comparison: comparison)
         
         if let extent = extent {
-            assert(extent.status == .inactive)
+            graph.assert(extent.status == .inactive)
             state.owner = extent
             extent.resources.append(state)
         } else {
             resources.append(state)
         }
-        
-#if DEBUG
-        onResourceCreated?(state)
-#endif
         
         return state
     }
@@ -353,13 +338,13 @@ public class BGExtentBuilderGeneric: NSObject {
                 }
         }
         
-        let mainBehavior = BGBehavior(supplies: mainBehaviorStaticSupplies, demands: mainBehaviorStaticDemands) { extent in
+        let mainBehavior = BGBehavior(graph: graph, supplies: mainBehaviorStaticSupplies, demands: mainBehaviorStaticDemands) { extent in
             body(extent as! Extent)
         }
         weakMainBehavior = mainBehavior
         
         if let extent = extent {
-            assert(extent.status == .inactive)
+            graph.assert(extent.status == .inactive)
             mainBehavior.owner = extent
             extent.behaviors.append(mainBehavior)
         } else {

--- a/BGSwift/Classes/BGResource.swift
+++ b/BGSwift/Classes/BGResource.swift
@@ -381,6 +381,12 @@ public class BGState<Type>: BGResource, BGResourceInternal {
         }
     }
     
+    func setInitialValue(_ value: Type) {
+        graph?.assert(owner == nil || owner?.status == .inactive)
+        _prevValue = value
+        _value = value
+    }
+    
     public func update(_ newValue: Type, forced: Bool = false) {
         guard case .updateable(let graph, let event) = updateable else {
             return

--- a/BGSwift/Classes/BGResource.swift
+++ b/BGSwift/Classes/BGResource.swift
@@ -98,7 +98,7 @@ extension BGResourceInternal {
         }
         
         if let currentBehavior = graph.currentRunningBehavior, currentBehavior !== supplier {
-            assert(currentBehavior.demands.first(where: { $0.resource === self }) != nil,
+            graph.assert(currentBehavior.demands.first(where: { $0.resource === self }) != nil,
                    "Accessed a resource in a behavior that was not declared as a demand.")
         }
     }
@@ -110,25 +110,25 @@ extension BGResourceInternal {
         }
         
         guard let currentEvent = graph.currentEvent else {
-            assertionFailure("Can only update a resource during an event.")
+            graph.assertionFailure("Can only update a resource during an event.")
             return .notUpdatable
         }
         
         guard let owner = owner else {
-            assertionFailure("Cannot update a resource that does not belong to an extent.")
+            graph.assertionFailure("Cannot update a resource that does not belong to an extent.")
             return .notUpdatable
         }
         
         if let behavior = supplier {
             
             guard graph.currentRunningBehavior === behavior else {
-                assertionFailure("Cannot update a resource with a supplying behavior during an action.")
+                graph.assertionFailure("Cannot update a resource with a supplying behavior during an action.")
                 return .notUpdatable
             }
         } else {
             if self !== owner._added {
                 guard graph.processingAction else {
-                    assertionFailure("Cannot update a resource with no supplying behaviour outside an action.")
+                    graph.assertionFailure("Cannot update a resource with no supplying behaviour outside an action.")
                     return .notUpdatable
                 }
             }
@@ -136,7 +136,7 @@ extension BGResourceInternal {
         
         guard _event.sequence < currentEvent.sequence else {
             // assert or fail?
-            assertionFailure("Can only update a resource once per event.")
+            graph.assertionFailure("Can only update a resource once per event.")
             return .notUpdatable
         }
         
@@ -349,7 +349,7 @@ public class BGState<Type>: BGResource, BGResourceInternal {
     var _prevValue: Type?
     private var comparison: ((_ lhs: Type, _ rhs: Type) -> Bool)?
     
-    init(_ value: Type, comparison: ((_ lhs: Type, _ rhs: Type) -> Bool)?) {
+    internal init(_ value: Type, comparison: ((_ lhs: Type, _ rhs: Type) -> Bool)?) {
         self.comparison = comparison
         self._value = value
         self._prevValue = value

--- a/Example/Tests/AssertionTests.swift
+++ b/Example/Tests/AssertionTests.swift
@@ -22,7 +22,7 @@ class AssertionTests: XCTestCase {
         }
         
         b.behavior().demands([b.added]).runs { extent in
-            assertionHit = CheckAssertionHit {
+            assertionHit = CheckAssertionHit(graph: g) {
                 _ = r.justUpdated()
             }
         }
@@ -43,7 +43,7 @@ class AssertionTests: XCTestCase {
         let r = b.moment()
         
         b.behavior().demands([b.added]).runs { extent in
-            assertionHit = CheckAssertionHit {
+            assertionHit = CheckAssertionHit(graph: g) {
                 _ = r.justUpdated()
             }
         }

--- a/Example/Tests/BGExtentTests.swift
+++ b/Example/Tests/BGExtentTests.swift
@@ -73,7 +73,7 @@ class BGExtentTests: XCTestCase {
         
         // |> When it is added again
         // |> Then there is an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             e.addToGraphWithAction()
         }
     }
@@ -84,7 +84,7 @@ class BGExtentTests: XCTestCase {
         
         // |> When added outside an event
         // |> Then there is an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             e.addToGraph()
         }
     }
@@ -96,7 +96,7 @@ class BGExtentTests: XCTestCase {
         
         // |> When added outside an event
         // |> Then there is an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             e.removeFromGraph()
         }
     }
@@ -115,6 +115,42 @@ class BGExtentTests: XCTestCase {
         let e2 = MyExtent(graph: self.g)
         
         XCTAssertEqual(e2.r1.debugName, "MyExtent.r1")
+    }
+    
+    func testCanTrackWhenExtentsAreAdded() {
+        // |> Given a graph with debugOnExtentAdded defined
+        var addedExtents: [BGExtent] = []
+        var addedResources: [any BGResource] = []
+        g.debugOnExtentAdded = {
+            addedExtents.append($0)
+            addedResources.append(contentsOf: $0.allResources)
+        }
+        
+        // |> When an extent is added
+        let b1 = BGExtentBuilder<BGExtent>(graph: g)
+        let _ = b1.moment()
+        let e1 = BGExtent(builder: b1)
+        
+        e1.addToGraphWithAction()
+        
+        // |> Then callback is called
+        XCTAssertEqual(e1, addedExtents[0])
+        XCTAssertEqual(1, addedExtents.count)
+        XCTAssertEqual(2, addedResources.count) // _added is a default resource
+        
+        // |> And when callback is undefined
+        g.debugOnExtentAdded = nil
+        
+        // and another extent is added
+        let b2 = BGExtentBuilder<BGExtent>(graph: g)
+        let _ = b2.moment()
+        let e2 = BGExtent(builder: b2)
+        
+        e2.addToGraphWithAction()
+        
+        // |> Then callback is not called
+        XCTAssertEqual(1, addedExtents.count)
+        XCTAssertEqual(2, addedResources.count)
     }
     
 }

--- a/Example/Tests/BGGraphTests.swift
+++ b/Example/Tests/BGGraphTests.swift
@@ -38,7 +38,7 @@ class BGGraphTests: XCTestCase {
         
         // |> When it is added to the graph
         // |> Then it will raise an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             e.addToGraphWithAction()
         }
     }
@@ -51,7 +51,7 @@ class BGGraphTests: XCTestCase {
         
         // |> When a behavior sets a static supply that is already supplied by another behavior
         // |> Then it will raise an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             b.behavior().supplies([rA]).runs { extent in
                 // nothing
             }
@@ -66,7 +66,7 @@ class BGGraphTests: XCTestCase {
         
         // |> When a behavior sets a dynamic supply that is already supplied by another behavior
         // |> Then it will raise an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             g.action {
                 bhv.setDynamicSupplies([self.rA])
             }
@@ -83,13 +83,13 @@ class BGGraphTests: XCTestCase {
         
         // |> When updating demands outside of event
         // |> Then there is an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             bhv.setDynamicDemands([rA])
         }
         
         // |> And when updating supplies outside of event
         // |> Then there is an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             bhv.setDynamicSupplies([rB])
         }
     }

--- a/Example/Tests/BGMomentTests.swift
+++ b/Example/Tests/BGMomentTests.swift
@@ -129,7 +129,7 @@ class BGMomentTests: XCTestCase {
         // |> When it is updated
         var errorHappened = false
         g.action {
-            errorHappened = CheckAssertionHit {
+            errorHappened = CheckAssertionHit(graph: self.g) {
                 mr1.update()
             }
         }
@@ -147,7 +147,7 @@ class BGMomentTests: XCTestCase {
         
         // |> When updating outside of an event
         // |> Then it should fail
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             mr1.update()
         }
     }
@@ -168,7 +168,7 @@ class BGMomentTests: XCTestCase {
 
         // |> When it is updated by the wrong behavior
         // |> Then it should throw
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             self.g.action {
                 mr1.update()
             }
@@ -181,7 +181,7 @@ class BGMomentTests: XCTestCase {
         let mr2 = bld.moment()
         var updateFailed = false
         bld.behavior().demands([mr1]).runs { extent in
-            updateFailed = CheckAssertionHit {
+            updateFailed = CheckAssertionHit(graph: self.g) {
                 mr2.update()
             }
         }
@@ -208,7 +208,7 @@ class BGMomentTests: XCTestCase {
         // |> When we try updating that moment in an action
         var updateFailed = false
         self.g.action {
-            updateFailed = CheckAssertionHit {
+            updateFailed = CheckAssertionHit(graph: self.g) {
                 mr1.update()
             }
         }

--- a/Example/Tests/BGStateTests.swift
+++ b/Example/Tests/BGStateTests.swift
@@ -232,7 +232,7 @@ class BGStateTests : XCTestCase {
         ext = BGExtent(builder: bld)
         ext.addToGraphWithAction()
         
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             r_a.updateWithAction(1)
         }
     }
@@ -260,7 +260,7 @@ class BGStateUpdateTests: XCTestCase {
     }
         
     override func tearDown() {
-        onAssertionFailure = nil
+        g.debugOnAssertionFailure = nil
     }
     
     // MARK: Non-Equatable, Non-Object

--- a/Example/Tests/BGStateTests.swift
+++ b/Example/Tests/BGStateTests.swift
@@ -187,6 +187,42 @@ class BGStateTests : XCTestCase {
 //                expect(r_a.value) == 1
 //            }
     
+    func testCanUpdateStateBeforeAdding() {
+        // |> Given a state resource that hasn't been added
+        let r = bld.state(0)
+        ext = BGExtent(builder: bld)
+        
+        // |> When we update
+        r.setInitialValue(1)
+        // |> Then it's value is the new initial value
+        XCTAssertEqual(r.value, 1)
+        XCTAssertEqual(r._prevValue, 1)
+    }
+    
+    func testCanUpdateStateBeforeBuildingExtent() {
+        // |> Given a state resource that hasn't been added
+        let r = bld.state(0)
+        
+        // |> When we update
+        r.setInitialValue(1)
+        // |> Then it's value is the new initial value
+        XCTAssertEqual(r.value, 1)
+        XCTAssertEqual(r._prevValue, 1)
+    }
+    
+    func testCannotSetInitialValueAfterAdding() {
+        // |> Given a state that has been added
+        let r = bld.state(0)
+        ext = BGExtent(builder: bld)
+        ext.addToGraphWithAction()
+        
+        // |> when we try to set initial value
+        // |> then it will assert
+        TestAssertionHit(graph: g) {
+            r.setInitialValue(1)
+        }
+    }
+    
     func testEnsuresCanUpdateChecksAreRun() {
         // NOTE: there are multiple canUpdate checks, this just ensures that
         // code path is followed

--- a/Example/Tests/ConcurrencyTests.swift
+++ b/Example/Tests/ConcurrencyTests.swift
@@ -243,7 +243,7 @@ class ConcurrencyTests: XCTestCase {
     
     func testSyncNestedActionsDisallowed() {
         let g = BGGraph()
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             g.action {
                 g.action(syncStrategy:.sync) {
                 }
@@ -271,7 +271,7 @@ class ConcurrencyTests: XCTestCase {
         
         // |> When that behavior runs
         // |> Then it should throw an error
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             r1.updateWithAction()
         }
     }
@@ -302,7 +302,7 @@ class ConcurrencyTests: XCTestCase {
         
         // |> When that behavior runs
         // |> Then is should be allowed?
-        let failed = CheckAssertionHit {
+        let failed = CheckAssertionHit(graph: g) {
             r1.updateWithAction()
         }
         XCTAssertFalse(failed)

--- a/Example/Tests/DynamicsTests.swift
+++ b/Example/Tests/DynamicsTests.swift
@@ -734,7 +734,7 @@ class DynamicsTests: XCTestCase {
         }
 
         // |> Then the most recent update should hold
-        let failed = CheckAssertionHit {
+        let failed = CheckAssertionHit(graph: g) {
             rA.updateWithAction(1)
         }
         XCTAssertFalse(failed)

--- a/Example/Tests/EventTests.swift
+++ b/Example/Tests/EventTests.swift
@@ -145,7 +145,7 @@ class EventTests: XCTestCase {
     func testSideEffectsMustBeCreatedInsideEvent() {
         // |> When a side effect is created outside of an event
         // |> Then an error will be raised
-        TestAssertionHit {
+        TestAssertionHit(graph: g) {
             self.g.sideEffect {
                 // nothing
             }

--- a/Example/Tests/TestSupport.swift
+++ b/Example/Tests/TestSupport.swift
@@ -6,22 +6,22 @@ import Foundation
 import XCTest
 @testable import BGSwift
 
-func TestAssertionHit(_ code: () -> (), _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
-    let assertionHit = CheckAssertionHit(code)
+func TestAssertionHit(graph: BGGraph, _ code: () -> (), _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+    let assertionHit = CheckAssertionHit(graph: graph, code)
     
     if !assertionHit {
         XCTFail(message(), file: file, line: line)
     }
 }
 
-func CheckAssertionHit(_ code: () -> ()) -> Bool {
+func CheckAssertionHit(graph: BGGraph, _ code: () -> ()) -> Bool {
     var assertionHit = false
-    BGSwift.onAssertionFailure = { _, _, _ in
+    graph.debugOnAssertionFailure = { _, _, _ in
         assertionHit = true
     }
     
     defer {
-        BGSwift.onAssertionFailure = nil
+        graph.debugOnAssertionFailure = nil
     }
     
     code()


### PR DESCRIPTION

- Removed the global overriding for asserts. Now you can offer an overload on an individual BGGraph instance.
- Removed the global callback for extents and resources being created. Now you can define debugOnExtentAdded on a BGGraph instance which is a callback called for each extent added after graph has been updated. If you want to see which resources or behaviors are added you can query them on the extent object passed into the callback.
- Also added a setInitialState on BGState so it can be updated before the extent has been added if we don't have the correct initial state at the time of calling the constructor.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
